### PR TITLE
Topics belong to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'jbuilder', '~> 2.5'
 # gem 'bcrypt', '~> 3.1.7'
 gem 'devise'
 
+gem 'shoulda'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,12 @@ GEM
     selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.2)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -232,6 +238,7 @@ DEPENDENCIES
   rspec-rails (>= 3.5.0)
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,7 +1,7 @@
 class TopicsController < ApplicationController
 
-  before_action :find_topic, only: [:show, :edit, :update]
   before_action :authenticate_user!, only: [:new, :destroy, :create, :edit, :update]
+  before_action :set_current_user_topic, only: [:update, :destroy, :edit]
 
   def index
     @topics = Topic.all
@@ -12,8 +12,7 @@ class TopicsController < ApplicationController
   end
 
   def create
-    @topic = Topic.create(topic_params)
-    @topic.user_id = current_user.id
+    @topic = current_user.topics.new(topic_params)
     if @topic.save
       redirect_to topics_path
     else
@@ -22,14 +21,16 @@ class TopicsController < ApplicationController
   end
 
   def show
+    @topic = Topic.find(params[:id])
   end
 
   def destroy
-    Topic.find(params[:id]).destroy
+    @topic.destroy
     redirect_to topics_path
   end
 
   def edit
+    render :edit
   end
 
   def update
@@ -42,8 +43,8 @@ class TopicsController < ApplicationController
 
   private
 
-  def find_topic
-    @topic = Topic.find(params[:id])
+  def set_current_user_topic
+    @topic = current_user.topics.find(params[:id])
   end
 
   def topic_params

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,7 @@
 class TopicsController < ApplicationController
 
   before_action :find_topic, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :destroy, :create, :edit, :update]
 
   def index
     @topics = Topic.all

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -13,6 +13,7 @@ class TopicsController < ApplicationController
 
   def create
     @topic = Topic.create(topic_params)
+    @topic.user_id = current_user.id
     if @topic.save
       redirect_to topics_path
     else

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,5 @@
 class Topic < ApplicationRecord
   validates :name, presence: true
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :email, uniqueness: true
+
+  has_many :topics
 end

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -3,8 +3,11 @@
 
   <h2> <%= @topic.name %></h2>
 
-  <%= button_to 'Delete Topic', topic_path(@topic), method: :delete, data: { confirm: "Are you sure?" } %>
+  <% if user_signed_in? %>
+    <%= button_to 'Delete Topic', topic_path(@topic), method: :delete, data: { confirm: "Are you sure?" } %>
+    <%= link_to 'Edit Topic', edit_topic_path(@topic.id) %>
+  <% end %>
 
-  <%= link_to 'Edit Topic', edit_topic_path(@topic.id) %>
+  <%= link_to 'Back to topics page', topics_path %>
 
 </section>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -3,7 +3,7 @@
 
   <h2> <%= @topic.name %></h2>
 
-  <% if user_signed_in? %>
+  <% if @topic.user == current_user %>
     <%= button_to 'Delete Topic', topic_path(@topic), method: :delete, data: { confirm: "Are you sure?" } %>
     <%= link_to 'Edit Topic', edit_topic_path(@topic.id) %>
   <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -5,9 +5,12 @@
 
 <%= link_to 'View Topics', topics_url %>
 </br>
-<%= link_to 'Sign Up', new_user_registration_url %>
-</br>
-<%= link_to 'Log In', new_user_session_url %>
-</br>
-<%= link_to 'Log Out', destroy_user_session_url, method: :delete %>
+<% if user_signed_in? %>
+  <%= link_to 'Log Out', destroy_user_session_url, method: :delete %>
+<% else %>
+  <%= link_to 'Sign Up', new_user_registration_url %>
+  </br>
+  <%= link_to 'Log In', new_user_session_url %>
+  </br>
+<% end %>
 

--- a/db/migrate/20180408120058_add_users_association_to_topics.rb
+++ b/db/migrate/20180408120058_add_users_association_to_topics.rb
@@ -1,0 +1,5 @@
+class AddUsersAssociationToTopics < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :topics, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180318143759) do
+ActiveRecord::Schema.define(version: 20180408120058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,8 @@ ActiveRecord::Schema.define(version: 20180318143759) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_topics_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +40,5 @@ ActiveRecord::Schema.define(version: 20180318143759) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "topics", "users"
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :topic do
-    user
     name "What is your secret superpower?"
+    user
   end
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :topic do
+    user
     name "What is your secret superpower?"
   end
 end

--- a/spec/models/topics_spec.rb
+++ b/spec/models/topics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'topics' do
+RSpec.describe Topic, type: :model do
 
   context 'name' do
     it "is required" do
@@ -12,5 +12,9 @@ RSpec.describe 'topics' do
   context 'factory' do
     subject { FactoryBot.build(:topic) }
     it { is_expected.to be_valid }
+  end
+
+  describe 'association' do
+    it { should belong_to(:user) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe User, type: :model do
       it { is_expected.to be_invalid }
     end
   end
+
+  describe 'associations' do
+    it { should have_many(:topics) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'devise'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -35,6 +35,12 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :system
+
+  # Warden config
+  config.include Warden::Test::Helpers
+  config.after :each do
+    Warden.test_reset!
+  end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/requests/topic_requests_spec.rb
+++ b/spec/requests/topic_requests_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Topic requests', type: :request do
+  let!(:topic) { FactoryBot.create :topic }
+  let(:user) { FactoryBot.create :user }
+
+  describe 'get#show' do
+    let(:dispatch_request) { get topic_path(topic) }
+    it_behaves_like 'NOT only for logged in users'
+  end
+
+  describe 'get#new' do
+    let(:dispatch_request) { get new_topic_path }
+    it_behaves_like 'only logged in users'
+  end
+
+  describe 'post#create' do
+    let(:dispatch_request){post topics_path, params: { topic: {name: "here is a new topic"} } }
+    it_behaves_like 'only logged in users'
+  end
+
+  describe 'get#edit' do
+    let(:dispatch_request) { get edit_topic_path(topic) }
+
+    it_behaves_like 'only logged in users'
+  end
+
+  describe 'put#update' do
+    let(:dispatch_request) {
+      put topic_path(topic), params: { topic: {:name => "ammended topic"} }
+    }
+
+    it_behaves_like 'only logged in users'
+  end
+
+  describe 'delete#destroy' do
+    let(:dispatch_request) { delete topic_path(topic) }
+
+    it_behaves_like 'only logged in users'
+  end
+end

--- a/spec/requests/topic_requests_spec.rb
+++ b/spec/requests/topic_requests_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'Topic requests', type: :request do
   let!(:topic) { FactoryBot.create :topic }
-  let(:user) { FactoryBot.create :user }
+  let(:user) { topic.user }
 
   describe 'get#show' do
     let(:dispatch_request) { get topic_path(topic) }
     it_behaves_like 'NOT only for logged in users'
+    it_behaves_like 'NOT just for topic owners'
   end
 
   describe 'get#new' do
@@ -23,6 +24,7 @@ RSpec.describe 'Topic requests', type: :request do
     let(:dispatch_request) { get edit_topic_path(topic) }
 
     it_behaves_like 'only logged in users'
+    it_behaves_like 'topic owners only'
   end
 
   describe 'put#update' do
@@ -31,11 +33,13 @@ RSpec.describe 'Topic requests', type: :request do
     }
 
     it_behaves_like 'only logged in users'
+    it_behaves_like 'topic owners only'
   end
 
   describe 'delete#destroy' do
     let(:dispatch_request) { delete topic_path(topic) }
 
     it_behaves_like 'only logged in users'
+    it_behaves_like 'topic owners only'
   end
 end

--- a/spec/support/shared_examples/authentication_protected.rb
+++ b/spec/support/shared_examples/authentication_protected.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'only logged in users' do
+  it 'doesnt allow logged out users' do
+    dispatch_request
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it 'allows logged in users' do
+    login_as(user, scope: :user)
+    dispatch_request
+    expect(response).not_to redirect_to(new_user_session_path)
+  end
+end
+
+RSpec.shared_examples 'NOT only for logged in users' do
+  it 'allows logged out users' do
+    dispatch_request
+    expect(response).not_to redirect_to(new_user_session_path)
+  end
+end

--- a/spec/support/shared_examples/topic_owner_restrictions.rb
+++ b/spec/support/shared_examples/topic_owner_restrictions.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples 'topic owners only' do
+  it 'allows topic owner' do
+    login_as(topic.user, scope: :user)
+    dispatch_request
+    expect { dispatch_request }.not_to raise_error
+  end
+
+  it 'disallows users other than topic owner' do
+    login_as(FactoryBot.create(:user), scope: :user)
+    expect { dispatch_request }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end
+
+RSpec.shared_examples 'NOT just for topic owners' do
+  it 'disallows users other than topic owner' do
+    login_as(FactoryBot.create(:user), scope: :user)
+    expect { dispatch_request }.not_to raise_error
+  end
+end

--- a/spec/system/managing_topics_spec.rb
+++ b/spec/system/managing_topics_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe 'managing topics' do
     sign_in user
     visit topic_path(topic)
     click_link 'Edit Topic'
+    expect(page).to have_content('You need to sign in or sign up before continuing')
+    sign_in user
+    visit topic_path(topic)
+    click_link 'Edit Topic'
     expect(current_path).to eq edit_topic_path(topic)
     expect(page).to have_content 'What is your favourite colour'
     fill_in 'Name', with: ''

--- a/spec/system/managing_topics_spec.rb
+++ b/spec/system/managing_topics_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe 'managing topics' do
 
   scenario 'when deleting a topic' do
     visit topic_path(topic)
-    accept_confirm { click_on 'Delete Topic' }
-    expect(page).to have_content('You need to sign in or sign up before continuing')
+    expect(page).to have_no_content 'Delete Topic'
     sign_in user
     visit topic_path(topic)
     expect {
@@ -48,8 +47,7 @@ RSpec.describe 'managing topics' do
 
   scenario 'when editing a topic' do
     visit topic_path(topic)
-    click_link 'Edit Topic'
-    expect(page).to have_content('You need to sign in or sign up before continuing')
+    expect(page).to have_no_content 'Edit Topic'
     sign_in user
     visit topic_path(topic)
     click_link 'Edit Topic'

--- a/spec/system/managing_topics_spec.rb
+++ b/spec/system/managing_topics_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'managing topics' do
 
-  let!(:topic) { FactoryBot.create :topic, name: 'What is your favourite colour'}
-  let!(:user) { FactoryBot.create :user}
+  let(:user) { FactoryBot.create :user }
+  let!(:topic) {
+    FactoryBot.create :topic, name: 'What is your favourite colour'
+  }
 
   scenario 'when viewing' do
     visit topics_path
@@ -34,9 +36,17 @@ RSpec.describe 'managing topics' do
   end
 
   scenario 'when deleting a topic' do
+    # No delete button if not logged in
     visit topic_path(topic)
-    expect(page).to have_no_content 'Delete Topic'
+    expect(page).to have_no_button 'Delete Topic'
+
+    # can't delete if not the topic owner
     sign_in user
+    visit topic_path(topic)
+    expect(page).to have_no_button 'Delete Topic'
+
+    # can delete as the topic owner
+    sign_in topic.user
     visit topic_path(topic)
     expect {
       accept_confirm { click_on 'Delete Topic' }
@@ -45,10 +55,18 @@ RSpec.describe 'managing topics' do
     expect(page).to have_no_content 'What is your favourite colour'
   end
 
-  scenario 'when editing a topic' do
+  scenario 'when updating a topic' do
+    # No link to edit if not logged in
     visit topic_path(topic)
-    expect(page).to have_no_content 'Edit Topic'
+    expect(page).to have_no_link 'Edit Topic'
+
+    # can't edit if not the topic owner
     sign_in user
+    visit topic_path(topic)
+    expect(page).to have_no_link 'Edit Topic'
+
+    # Can edit as the topic owner
+    sign_in topic.user
     visit topic_path(topic)
     click_link 'Edit Topic'
     expect(page).to have_content('You need to sign in or sign up before continuing')

--- a/spec/system/managing_topics_spec.rb
+++ b/spec/system/managing_topics_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'managing topics' do
 
   let!(:topic) { FactoryBot.create :topic, name: 'What is your favourite colour'}
+  let!(:user) { FactoryBot.create :user}
 
   scenario 'when viewing' do
     visit topics_path
@@ -11,6 +12,10 @@ RSpec.describe 'managing topics' do
   end
 
   scenario 'when creating a topic' do
+    visit topics_path
+    click_link 'New Topic'
+    expect(page).to have_content('You need to sign in or sign up before continuing')
+    sign_in user
     visit topics_path
     click_link 'New Topic'
     click_button 'Create'
@@ -30,6 +35,10 @@ RSpec.describe 'managing topics' do
 
   scenario 'when deleting a topic' do
     visit topic_path(topic)
+    accept_confirm { click_on 'Delete Topic' }
+    expect(page).to have_content('You need to sign in or sign up before continuing')
+    sign_in user
+    visit topic_path(topic)
     expect {
       accept_confirm { click_on 'Delete Topic' }
       expect(current_path).to eq topics_path
@@ -38,6 +47,10 @@ RSpec.describe 'managing topics' do
   end
 
   scenario 'when editing a topic' do
+    visit topic_path(topic)
+    click_link 'Edit Topic'
+    expect(page).to have_content('You need to sign in or sign up before continuing')
+    sign_in user
     visit topic_path(topic)
     click_link 'Edit Topic'
     expect(current_path).to eq edit_topic_path(topic)


### PR DESCRIPTION
Based off of #7 
For just changes for this PR see https://github.com/Mentessi/toastmasters/compare/only-logged-in-users...topics-belong-to-users

-------------

Whoooah - this felt like a big improvement from a workflow perspective. I have rebased and sorted out the commit order & content to get closer to something that is incrementally deployable (dont think I've quite nailed commit messages yet). Covered database associations, 'shoulda' gem for tests, restricted what the user sees based on whether it's their own topic or not and tested it all too. Obviously they'll be stuff that I haven't done quite right, but actually chuffed with my progress - you'll make a developer out of me yet dude!! :-D