### PR TITLE
Edit collections topics

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -48,6 +48,6 @@ class CollectionsController < ApplicationController
   end
 
   def collection_params
-    params.require(:collection).permit(:name)
+    params.require(:collection).permit(:name, :id, collections_topics_attributes: [:id, :collection_id, :topic_id, :_destroy])
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,4 +3,5 @@ class Collection < ApplicationRecord
   has_many :topics, through: :collections_topics
   belongs_to :user
   validates :name, presence: true
+  accepts_nested_attributes_for :collections_topics, allow_destroy: true
 end

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -15,9 +15,39 @@
 <% end %>
 
 <div>
-  <%= form_for @collection do |f| %>
-    <%= f.label :name %>
-    <%= f.text_field :name %>
-    <%= f.submit %>
+    <%= form_with model: @collection, local: true, method: :patch, url: collection_path(@collection) do |f| %>
+
+      <%- collections_topics_lookup = @collection
+        .collections_topics
+        .reduce({}) {|memo, ct|
+          memo[ct.topic_id] = ct.id
+          memo
+        } %>
+
+      <%= f.label :name %>
+      <%= f.text_field :name, id: 'collection_name' %>
+
+      <% @collection.topics.each_with_index do |topic, index| %>
+
+      <%- collections_topic_id = collections_topics_lookup.fetch(topic.id, '') %>
+
+      <%= hidden_field_tag "collection[collections_topics_attributes][#{index}][_destroy]", 1, id: "hidden-destroy-#{topic.id}" %>
+
+      <%= check_box_tag "collection[collections_topics_attributes][#{index}][_destroy]", 0, collections_topic_id.present? %>
+
+      <%= label_tag "collection[collections_topics_attributes][#{index}][_destroy]", topic.name %>
+
+      <%= hidden_field_tag "collection[collections_topics_attributes][#{index}][id]", collections_topic_id %>
+
+      <%= hidden_field_tag "collection[collections_topics_attributes][#{index}][topic_id]", topic.id %>
+
+      <%= hidden_field_tag "collection[collections_topics_attributes][#{index}][collection_id]", @collection.id %>
+
+      </br>
+
+    <% end %>
+
+    <%= button_to 'Update' %>
+
   <% end %>
 </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,4 +1,6 @@
 <h1><%= @collection.name %></h1>
+</br>
+<h2>Topics:</h2>
 <% @collection.topics.each do |topic| %>
   <%= topic.name %>
   </br>

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Collection, type: :model do
     it { should have_many(:collections_topics) }
     it { should have_many(:topics) }
     it { should belong_to(:user) }
+    it { should accept_nested_attributes_for(:collections_topics) }
   end
 
   describe 'valildations' do

--- a/spec/system/managing_collection_memberships_spec.rb
+++ b/spec/system/managing_collection_memberships_spec.rb
@@ -3,51 +3,70 @@ require 'rails_helper'
 RSpec.describe 'managing collections memberships' do
   let!(:collection1) { FactoryBot.create :collection, name: 'Dogs and cats' }
   let!(:collection2) { FactoryBot.create :collection, name: 'Monkeys and lamas', user: collection1.user }
-  let!(:topic){ FactoryBot.create :topic, name: 'dog topic' }
+  let!(:topic1){ FactoryBot.create :topic, name: 'dog topic' }
+  let!(:topic2){ FactoryBot.create :topic, name: 'cat topic' }
   let!(:user){ collection1.user }
 
   # From Topics show page:
-  scenario 'add a topic to a collection' do
+  scenario 'add a topic to a collection on topic show page' do
     # No add topic to collection option if not logged in
-    visit topic_path(topic)
+    visit topic_path(topic1)
     expect(page).to have_no_content 'Add to collection'
 
     # Can only add to own collections
     sign_in user
-    visit topic_path(topic)
+    visit topic_path(topic1)
     expect(page).to have_no_content('Rabbits and hamsters')
 
     #Can add own topic to collection
     sign_in user
-    visit topic_path(topic)
+    visit topic_path(topic1)
     expect(page).to have_content('Add to collection')
     expect(page).to have_content collection1.name
-    find('label', :text => collection1.name).click
+    find('label', text: collection1.name).click
     click_button 'Update'
-    expect(current_path).to eq topic_path(topic)
+    expect(current_path).to eq topic_path(topic1)
     expect(page).to have_content "collection(s) successfully updated"
     expect(page).to have_field(collection1.name, checked: true, visible: false)
 
     #can update multiple collections at once when logged in
-    find('label', :text => collection1.name).click
-    find('label', :text => collection2.name).click
+    find('label', text: collection1.name).click
+    find('label', text: collection2.name).click
     click_button 'Update'
-    expect(current_path).to eq topic_path(topic)
+    expect(current_path).to eq topic_path(topic1)
     expect(page).to have_content "collection(s) successfully updated"
     expect(page).to have_field(collection1.name, checked: false, visible: false)
     expect(page).to have_field(collection2.name, checked: true, visible: false)
   end
 
-  # From Collections show page:
-  scenario 'add a topic to a collection' do
+  # From Collections edit page:
+  scenario 'remove a topic from a collection on collection edit page' do
 
-    collection1.topics << topic
+    collection1.topics << topic1
+    collection1.topics << topic2
 
+    # Can remove a topic from a collection
     sign_in user
     visit collection_path(collection1)
+    expect(page).to have_content 'dog topic'
+    expect(page).to have_content 'cat topic'
     click_link 'Edit Collection'
-    expect(page).to have_content 'Dog topic'
+    expect(page).to have_field(topic1.name, checked: true, visible: false)
+    expect(page).to have_field(topic1.name, checked: true, visible: false)
+    find('label', text: topic1.name).click
+    click_button 'Update'
+    expect(page).to have_no_content 'dog topic'
+    expect(page).to have_content 'cat topic'
+    expect(current_path).to eq collection_path(collection1)
 
-
+    # Can remove topics and edit collection name at the same time
+    click_link 'Edit Collection'
+    expect(page).to have_field(topic2.name, checked: true, visible: false)
+    find('label', text: topic2.name).click
+    fill_in "Name", with: 'No more animal topics'
+    click_button 'Update'
+    expect(page).to have_no_content 'cat topic'
+    expect(page).to have_content 'No more animal topics'
+    expect(current_path).to eq collection_path(collection1)
   end
 end

--- a/spec/system/managing_collection_memberships_spec.rb
+++ b/spec/system/managing_collection_memberships_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'managing collections memberships' do
+  let!(:collection1) { FactoryBot.create :collection, name: 'Dogs and cats' }
+  let!(:collection2) { FactoryBot.create :collection, name: 'Monkeys and lamas', user: collection1.user }
+  let!(:topic){ FactoryBot.create :topic, name: 'dog topic' }
+  let!(:user){ collection1.user }
+
+  # From Topics show page:
+  scenario 'add a topic to a collection' do
+    # No add topic to collection option if not logged in
+    visit topic_path(topic)
+    expect(page).to have_no_content 'Add to collection'
+
+    # Can only add to own collections
+    sign_in user
+    visit topic_path(topic)
+    expect(page).to have_no_content('Rabbits and hamsters')
+
+    #Can add own topic to collection
+    sign_in user
+    visit topic_path(topic)
+    expect(page).to have_content('Add to collection')
+    expect(page).to have_content collection1.name
+    find('label', :text => collection1.name).click
+    click_button 'Update'
+    expect(current_path).to eq topic_path(topic)
+    expect(page).to have_content "collection(s) successfully updated"
+    expect(page).to have_field(collection1.name, checked: true, visible: false)
+
+    #can update multiple collections at once when logged in
+    find('label', :text => collection1.name).click
+    find('label', :text => collection2.name).click
+    click_button 'Update'
+    expect(current_path).to eq topic_path(topic)
+    expect(page).to have_content "collection(s) successfully updated"
+    expect(page).to have_field(collection1.name, checked: false, visible: false)
+    expect(page).to have_field(collection2.name, checked: true, visible: false)
+  end
+
+  # From Collections show page:
+  scenario 'add a topic to a collection' do
+
+    collection1.topics << topic
+
+    sign_in user
+    visit collection_path(collection1)
+    click_link 'Edit Collection'
+    expect(page).to have_content 'Dog topic'
+
+
+  end
+end

--- a/spec/system/managing_collections_spec.rb
+++ b/spec/system/managing_collections_spec.rb
@@ -3,11 +3,9 @@ require 'rails_helper'
 RSpec.describe 'managing collections' do
   let!(:collection1) { FactoryBot.create :collection, name: 'Dogs and cats' }
   let!(:collection2) { FactoryBot.create :collection, name: 'Rabbits and hamsters' }
-  let!(:collection3) { FactoryBot.create :collection, name: 'Monkeys and lamas', user: collection1.user }
   let!(:unrelated_topic){ FactoryBot.create :topic, name: 'unrelated' }
   let!(:topic){ FactoryBot.create :topic, name: 'dog topic' }
   let!(:user){ collection1.user }
-  let!(:user2){ collection2.user }
 
   scenario 'when viewing collections' do
     visit collections_path
@@ -83,36 +81,5 @@ RSpec.describe 'managing collections' do
       expect(current_path).to eq collections_path
     }.to change(Collection, :count).by(-1)
     expect(page).to have_no_content 'Dogs and cats'
-  end
-
-  scenario 'add a topic to a collection' do
-    # No add topic to collection option if not logged in
-    visit topic_path(topic)
-    expect(page).to have_no_content 'Add to collection'
-
-    # Can only add to own collections
-    sign_in user
-    visit topic_path(topic)
-    expect(page).to have_no_content('Rabbits and hamsters')
-
-    #Can add own topic to collection
-    sign_in user
-    visit topic_path(topic)
-    expect(page).to have_content('Add to collection')
-    expect(page).to have_content collection1.name
-    find('label', :text => collection1.name).click
-    click_button 'Update'
-    expect(current_path).to eq topic_path(topic)
-    expect(page).to have_content "collection(s) successfully updated"
-    expect(page).to have_field(collection1.name, checked: true, visible: false)
-
-    #can update multiple collections at once when logged in
-    find('label', :text => collection1.name).click
-    find('label', :text => collection3.name).click
-    click_button 'Update'
-    expect(current_path).to eq topic_path(topic)
-    expect(page).to have_content "collection(s) successfully updated"
-    expect(page).to have_field(collection1.name, checked: false, visible: false)
-    expect(page).to have_field(collection3.name, checked: true, visible: false)
   end
 end

--- a/spec/system/managing_collections_spec.rb
+++ b/spec/system/managing_collections_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe 'managing collections' do
     expect(current_path).to eq edit_collection_path(collection1)
     expect(page).to have_content 'Dogs and cats'
     fill_in 'Name', with: ''
-    click_button 'Update Collection'
+    click_button 'Update'
     expect(page).to have_content "Name can't be blank"
     fill_in 'Name', with: 'rabbits'
-    click_button 'Update Collection'
+    click_button 'Update'
     expect(current_path).to eq collection_path(collection1)
     expect(page).to have_content 'rabbits'
   end


### PR DESCRIPTION
1. The checkbox form for managing a collections members is very similar to the checkbox form for adding topics to a collection from the topic show page... I wasn't sure if there was a way of combining the two in a partial with logic that changed behaviour based on what page it's shown on? or if, although this would be DRYer, it would also be more difficult to read (so not worth it?)

2. had to add 'local: true' for form_with because some ajax magic wasn't working - the error messages weren't displaying when I submitted a form with the name field blank.

3. The specs for topic management and collection management both had tests in for the managing of a collections topics memberships so I split them out, this felt like a sensible approach at the time, but I wasn't as sure when I came to commit it all(?) :shrugs:
